### PR TITLE
Fix option arrays for admin script

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,4 +1,7 @@
 jQuery(function($){
+  function toArray(obj){
+    return Array.isArray(obj) ? obj : Object.values(obj || {});
+  }
   function addBranzaRow(){
     var t = $('#kc_add_branza').prev('table').find('tbody');
     var idx = t.children('tr').length;
@@ -23,7 +26,9 @@ jQuery(function($){
     var t = $('#kc_add_style').prev('table').find('tbody');
     var idx = t.children('tr').length;
     var sel = '<select name="konf_style['+idx+'][branch]">';
-    (kcAdminData.branze||[]).forEach(function(b){ sel+='<option value="'+b.slug+'">'+b.title+'</option>'; });
+    toArray(kcAdminData.branze).forEach(function(b){
+      sel += '<option value="'+b.slug+'">'+b.title+'</option>';
+    });
     sel += '</select>';
     t.append('<tr data-index="'+idx+'">'+
       '<td>'+sel+'</td>'+
@@ -39,7 +44,9 @@ jQuery(function($){
     var t = $('#kc_add_feature').prev('table').find('tbody');
     var idx = t.children('tr').length;
     var cele = '';
-    (kcAdminData.cele||[]).forEach(function(c){ cele += '<label><input type="checkbox" name="konf_features['+idx+'][assigned][]" value="'+c.slug+'"> '+c.title+'</label><br>'; });
+    toArray(kcAdminData.cele).forEach(function(c){
+      cele += '<label><input type="checkbox" name="konf_features['+idx+'][assigned][]" value="'+c.slug+'"> '+c.title+'</label><br>';
+    });
     t.append('<tr data-index="'+idx+'">'+
       '<td><input name="konf_features['+idx+'][title]"></td>'+
       '<td><select name="konf_features['+idx+'][type]"><option value="funkcja">Funkcja</option><option value="automatyzacja">Automatyzacja</option><option value="integracja">Integracja</option></select></td>'+

--- a/wizard-konfigurator.php
+++ b/wizard-konfigurator.php
@@ -29,10 +29,14 @@ add_action('admin_enqueue_scripts', function($hook){
     if($hook !== 'toplevel_page_wizard-konfigurator') return;
     wp_enqueue_media();
     wp_enqueue_script('kc-admin-js', plugins_url('assets/js/admin.js', __FILE__), ['jquery'], null, true);
-    wp_localize_script('kc-admin-js', 'kcAdminData', [
-        'branze' => get_option('konf_branze'),
-        'cele'   => get_option('konf_cele')
-    ]);
+    wp_localize_script(
+        'kc-admin-js',
+        'kcAdminData',
+        [
+            'branze' => array_values((array) get_option('konf_branze')),
+            'cele'   => array_values((array) get_option('konf_cele')),
+        ]
+    );
 });
 
 // Render functions with is_array checks


### PR DESCRIPTION
## Summary
- reindex admin option arrays before localization
- add `toArray` helper in admin.js and use it when populating dropdowns

## Testing
- `php -l wizard-konfigurator.php`
- `php -l admin/settings-page.php`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d6884db0483329297c202fe5a4891