### PR TITLE
Fix wizard data arrays

### DIFF
--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -1,4 +1,7 @@
 (function($){
+  function toArray(obj){
+    return Array.isArray(obj)?obj:Object.values(obj||{});
+  }
   var postId = 0;
   var styleSel = [];
   function save(meta, cb){
@@ -12,10 +15,10 @@
       else alert('Błąd: '+res.data.message);
     });
   }
-  wizardData['branże'].forEach(function(b){
+  toArray(wizardData['branże']).forEach(function(b){
     $('#branze-list').append('<div class="branża" data-slug="'+b.slug+'">'+b.title+'</div>');
   });
-  wizardData.cele.forEach(function(c){
+  toArray(wizardData.cele).forEach(function(c){
     $('#cele-list').append('<div class="cel" data-slug="'+c.slug+'">'+c.title+'</div>');
   });
   // features will be rendered after selecting a goal
@@ -25,7 +28,7 @@
     var slug=$(this).data('slug');
     styleSel=[];
     $('#style-list').empty();
-    wizardData.style.forEach(function(s){
+    toArray(wizardData.style).forEach(function(s){
       if(s.branch===slug){
         var img=s.icon?'<img src="'+s.icon+'" alt="">':'';
         $('#style-list').append('<div class="style" data-title="'+s.title+'">'+img+'<span>'+s.title+'</span></div>');
@@ -65,7 +68,7 @@
     $(this).addClass('active');
     var slug=$(this).data('slug');
     $('#features-list').empty();
-    wizardData.features.forEach(function(f){
+    toArray(wizardData.features).forEach(function(f){
       if(!f.assigned || f.assigned.indexOf(slug)!==-1){
         $('#features-list').append('<label><input type="checkbox" value="'+f.title+'"> '+f.title+'</label><br>');
       }
@@ -88,5 +91,4 @@
     if(!email||email.indexOf('@')<0){ alert('Podaj poprawny email'); return; }
     save({budget:$('#budget').val(), email: email}, function(){
       alert('Wycena wysłana!'); location.reload();
-    });
-  });})(jQuery);
+    });  });})(jQuery);

--- a/wizard-konfigurator.php
+++ b/wizard-konfigurator.php
@@ -164,10 +164,10 @@ add_action('wp_enqueue_scripts', function() {
     wp_localize_script('wizard-js', 'wizardData', [
         'ajaxurl' => admin_url('admin-ajax.php'),
         'nonce'   => wp_create_nonce('wizard_nonce'),
-        'branże'  => get_option('konf_branze'),
-        'cele'    => get_option('konf_cele'),
-        'style'   => get_option('konf_style'),
-        'features'=> get_option('konf_features')
+        'branże'  => array_values((array) get_option('konf_branze')),
+        'cele'    => array_values((array) get_option('konf_cele')),
+        'style'   => array_values((array) get_option('konf_style')),
+        'features'=> array_values((array) get_option('konf_features'))
     ]);
 });
 add_action('wp_ajax_save_wizard_step', 'kc_save_step');


### PR DESCRIPTION
## Summary
- ensure wizard data arrays are normalized when enqueuing scripts
- add a helper to convert objects to arrays in the wizard script
- use the helper before iterating branże, cele, style and features

## Testing
- `npm test` *(fails: package.json missing)*
- `php -l wizard-konfigurator.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6ba38cdc83329bce1f40064e0d8b