### PR TITLE
Add email heading and validation

### DIFF
--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -133,7 +133,11 @@
     $('#budget').val(cost);
     updateBudgetText(cost);
     save({cel:$('.cel.active').data('slug'), features:feats, tel:$('#tel').val(), role:$('#role').val(), whatsapp:$('#whatsapp').prop('checked')?1:0},function(){
-      $('#step-2').fadeOut(200,function(){ $('#step-3').fadeIn(200); setProgress(3); });
+      $('#step-2').fadeOut(200,function(){
+        $('#step-3').fadeIn(200);
+        setProgress(3);
+        $('#finish').prop('disabled', true);
+      });
     });
   });
   $('#budget').on('input change',function(){
@@ -146,7 +150,11 @@
     $('#budget').val(total);
     updateBudgetText(total);
   });
+  var emailValid=false;
+  $('#email').on('input',function(){
+    emailValid=/^[^@]+@[^@]+\.[^@]+$/.test($(this).val().trim());
+    $('#finish').prop('disabled', !emailValid);
+  });
   $('#finish').click(function(){
     var email=$('#email').val();
-    if(!email||email.indexOf('@')<0){ alert('Podaj poprawny email'); return; }
-    save({budget:$('#budget').val(), email: email}, function(){      alert('Wycena wysłana!'); location.reload();    });  });})(jQuery);
+    if(!/^[^@]+@[^@]+\.[^@]+$/.test(email)){ alert('Podaj poprawny email'); return; }    save({budget:$('#budget').val(), email: email}, function(){      alert('Wycena wysłana!'); location.reload();    });  });})(jQuery);

--- a/templates/wizard-page.php
+++ b/templates/wizard-page.php
@@ -36,5 +36,7 @@
     <input type="range" id="budget" min="0" max="50000">
     <div id="budget-summary"></div>
     <div id="summary-list"></div>
-    <input id="email" placeholder="Twój email">
-    <button id="finish">Prześlij wycenę</button>  </div></div>
+    <h3>Email do przesłania wyceny</h3>
+    <input id="email" placeholder="Twój email">    <button id="finish" disabled>Prześlij wycenę</button>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add heading above email field
- validate email with regex before enabling submit button

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e47f115288332961e05f85acb7342