### PR TITLE
Ensure NIP & RODO required for step 1

### DIFF
--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -34,11 +34,15 @@
   function updateNext1(){
     var nipFilled = $('#nip').val().trim() !== '';
     var rodoOk    = $('#rodo').prop('checked');
-    if(styleSel.length>=1 && nipFilled && rodoOk){
-      $('#next-1').prop('disabled', false).show();
+    var allOk     = styleSel.length >= 1 && nipFilled && rodoOk;
+
+    if(styleSel.length >= 1){
+      $('#next-1').show();
     }else{
-      $('#next-1').prop('disabled', true).hide();
+      $('#next-1').hide();
     }
+
+    $('#next-1').prop('disabled', !allOk);
   }
   function updateBudgetText(v){
     var text='Budżet: '+v+' zł';


### PR DESCRIPTION
## Summary
- show the Next button when a style is selected but keep it disabled until NIP is filled and RODO checked
- enable the button only when style, NIP and RODO are all provided

## Testing
- `npm test` *(fails: ENOENT: no package.json)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e53de35088332a7a4909fec8ff5d5