### PR TITLE
Allow full-width steps in wizard

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -41,10 +41,9 @@ body {
 .step {
   padding: 20px;
   box-sizing: border-box;
-  width: calc(100% - 40px);
+  width: 100%;
   height: 100%;
   overflow-y: auto;
-  max-width: 600px;
   margin: 20px auto;
   background: #141919;
   border: none;


### PR DESCRIPTION
## Summary
- remove `.step` max-width restriction
- set `.step` width to 100%

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8497c2a08332a2bb749d76c8a250