### PR TITLE
Adjust wizard progress styling

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -14,9 +14,7 @@ body {
 }
 
 #wizard {
-  position: fixed;
-  top: 0;
-  left: 0;
+  top: auto;
   width: 100%;
   height: 100%;
   overflow: hidden;
@@ -28,13 +26,15 @@ body {
   left: 0;
   width: 100%;
   height: 5px;
-  background: #ccc;
+  background: #c79159;
+  z-index: 2;
 }
 
 #progress-bar {
   height: 5px;
-  background: linear-gradient(to right, var(--accent), #fff);
+  background: #c79159;
   width: 0%;
+  z-index: 2;
 }
 
 .step {
@@ -188,7 +188,8 @@ input::placeholder {
   transform: translateX(-50%);
   display: flex;
   gap: 10px;
-  color: var(--accent);
+  color: #c79159;
+  z-index: 2;
 }
 
 #progress-steps span { opacity: .5; }


### PR DESCRIPTION
## Summary
- remove fixed positioning from wizard container
- style progress indicators with brand color
- ensure progress elements stack above content

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686e7b90906883328425a0fe86bd68b4