### PR TITLE
Add overlay effect for grid items

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -70,6 +70,7 @@ body {
   text-align: center;
   backdrop-filter: blur(10px);
   transition: transform .2s, box-shadow .2s, border-color .2s, outline-color .2s;
+  position: relative;
 }
 
 .branch-select {
@@ -123,6 +124,18 @@ body {
   border-color: #c7a87a;
   outline: 1px solid #d1a54096;
   box-shadow: 0 4px 20px rgba(255,255,255,0.2);
+}
+
+.grid div:hover::after,
+.grid div.active::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,210,184,0.05);
+  border-radius: 16px;
 }
 
 button {


### PR DESCRIPTION
## Summary
- tweak `grid` items to be positioned relatively
- add pseudo-element overlay on hover and when active

## Testing
- `npm test` *(fails: could not find package.json)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e952f15cc8332b20cd3bac3435e1e