### PR TITLE
Fix grid image width

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -104,7 +104,7 @@ body {
 
 .grid div img {
   display: block;
-  width: 100%;
+  max-width: 90%;
   height: auto;
   margin: 0 auto 10px;
   border-radius: 5px;


### PR DESCRIPTION
## Summary
- prevent images from stretching

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e953105b88332b568ad74ad520241