### PR TITLE
Fix missing closing bracket in keyframes

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -192,6 +192,7 @@ button:hover {
 @keyframes shine {
   from { left: -150%; }
   to { left: 150%; }
+}
 .glass-control {
   background: #141919;
   color: #fff;


### PR DESCRIPTION
## Summary
- close `@keyframes shine` rule in `wizard.css`

## Testing
- `grep -n "keyframes shine" -n assets/css/wizard.css`


------
https://chatgpt.com/codex/tasks/task_e_686eb91d369c8332bcdd530c50631172