### PR TITLE
Improve glass styles

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -93,7 +93,9 @@ body {
 
 .branch-select {
   flex: 1 1 calc(50% - 20px);
-  background: #141919 url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'%3E%3Cpath d='M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6z'/%3E%3C/svg%3E") no-repeat right 16px center;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'%3E%3Cpath d='M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 16px center;
   background-size: 12px;
   padding: 20px;
   text-align: center;
@@ -109,11 +111,10 @@ body {
   border-color: var(--hover-border);
   outline: 1px solid var(--hover-border);
   box-shadow: 0 4px 20px rgba(255,255,255,0.2);
-  background-color: #141919;
 }
 
 .branch-select option {
-  background: #141919;
+  background: transparent;
   color: #fff;
 }
 
@@ -154,15 +155,16 @@ button {
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--cta);
+  background: rgba(255,255,255,0.3);
+  background: linear-gradient(180deg, rgba(255,255,255,0.4), rgba(255,255,255,0.2));
   color: #fff;
   padding: 15px 40px;
-  border: none;
-  border-radius: 40px;
+  border: 1px solid #d4af37;
+  border-radius: 50px;
   font-size: 18px;
   cursor: pointer;
   box-shadow: 0 2px 6px rgba(0,0,0,0.3);
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(12px);
   transition: all 0.2s ease-in-out;
 }
 button:hover {
@@ -172,8 +174,12 @@ button:hover {
 /* Call-to-action button with gradient background and shine effect */
 .cta-btn {
   position: relative;
-  background: linear-gradient(135deg, #ffdd00, #ff8800);
+  background: rgba(255,255,255,0.3);
+  background: linear-gradient(180deg, rgba(255,255,255,0.4), rgba(255,255,255,0.2));
   color: #3D3D3D;
+  border: 1px solid #d4af37;
+  border-radius: 50px;
+  backdrop-filter: blur(12px);
   overflow: hidden;
 }
 
@@ -193,12 +199,12 @@ button:hover {
   from { left: -150%; }
   to { left: 150%; }
 .glass-control {
-  background: #141919;
+  background: rgba(255,255,255,0.3);
+  background: linear-gradient(180deg, rgba(255,255,255,0.4), rgba(255,255,255,0.2));
   color: #fff;
-  border: 1px solid #01090c;
-  outline: 1px solid #3f3d38;
-  border-radius: 8px;
-  backdrop-filter: blur(10px);
+  border: 1px solid #d4af37;
+  border-radius: 40px;
+  backdrop-filter: blur(12px);
 }
 
 textarea,
@@ -219,14 +225,13 @@ select:focus {
   border-color: #c7a87a;
   outline: 1px solid #d1a54096;
   box-shadow: 0 4px 20px rgba(255,255,255,0.2);
-  background-color: #141919;
 }
 
 input[type=checkbox] {
   width: auto;
   display: inline-block;
   margin-right: 8px;
-  background: #141919;
+  background: transparent;
   border: 1px solid #3f3d38;
 }
 
@@ -239,7 +244,7 @@ input[type=checkbox] {
   height: 20px;
   border: 1px solid #3f3d38;
   border-radius: 4px;
-  background: #141919;
+  background: transparent;
   position: relative;
   transition: background .2s, transform .2s;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- tweak `.glass-control` for more elegant glass effect
- update `button` and `.cta-btn` to match glass style
- clean up input backgrounds and remove hardcoded colors

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686eba387d588332874c755a2b13111d