### PR TITLE
Clean up duplicate fields

### DIFF
--- a/templates/wizard-page.php
+++ b/templates/wizard-page.php
@@ -30,12 +30,9 @@
     <div class="grid" id="style-list"></div>
     <div id="after-style" style="display:none">
       <h4>Informacje dodatkowe</h4>
-      <textarea id="notes" placeholder="Opisz styl, jaki Ci się podoba"></textarea>
-      <input id="nip" placeholder="NIP firmy">
-      <label class="rodo-label"><input type="checkbox" id="rodo"><span class="custom-checkbox"></span> Zgoda na przetwarzanie danych zgodnie z naszą <a href="/polityka-prywatnosci" target="_blank">polityką prywatności</a></label>
       <textarea id="notes" class="glass-control" placeholder="Opisz styl jaki Ci się podoba"></textarea>
       <input id="nip" class="glass-control" placeholder="NIP firmy">
-      <label class="rodo-label"><input type="checkbox" id="rodo"> Zgoda na przetwarzanie danych zgodnie z naszą <a href="/polityka-prywatnosci" target="_blank">polityką prywatności</a></label>
+      <label class="rodo-label"><input type="checkbox" id="rodo"><span class="custom-checkbox"></span> Zgoda na przetwarzanie danych zgodnie z naszą <a href="/polityka-prywatnosci" target="_blank">polityką prywatności</a></label>
       <button id="next-1" class="cta-btn">Dalej</button>
     </div>
   </div>
@@ -70,13 +67,9 @@
     <input type="range" id="budget" min="0" max="50000" class="glass-control">
     <div id="budget-summary"></div>
     <div id="summary-list"></div>
-    <h3 class="subheadline">E-mail do przesłania wyceny</h3>
-    <input id="email" placeholder="Twój e-mail">
-    <h3>Email do przesłania wyceny</h3>
-    <input id="email" placeholder="Twój email">
-    <button id="finish" class="cta-btn" disabled>Prześlij wycenę</button>
-    <input id="email" class="glass-control" placeholder="Twój email">
-    <button id="finish" disabled>Prześlij wycenę</button>
+      <h3 class="subheadline">E-mail do przesłania wyceny</h3>
+      <input id="email" class="glass-control" placeholder="Twój email">
+      <button id="finish" class="cta-btn" disabled>Prześlij wycenę</button>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- remove repeated notes, nip, rodo label and email fields
- keep only one CTA button per step and ensure `glass-control` classes

## Testing
- `php -l templates/wizard-page.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686eba3e77a08332bd943739f152d41f