### PR TITLE
Add phone carousel and styling

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -367,14 +367,32 @@ input::placeholder {
 .phone-carousel {
   display: flex;
   overflow-x: auto;
-  gap: 20px;
+  gap: -40px;
   padding-bottom: 10px;
   scroll-snap-type: x mandatory;
 }
 .phone-carousel::-webkit-scrollbar { display: none; }
 .phone-carousel .style { flex: 0 0 auto; scroll-snap-align: start; }
 .style { position: relative; }
-.style img { display: block; width: 100%; height: auto; border-radius: 8px; }
+.style img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.6);
+  -webkit-box-reflect: below 0 linear-gradient(transparent, rgba(255,255,255,0.1));
+}
+.style:hover,
+.style.active {
+  border-color: #d4af37;
+  outline-color: #d4af37;
+  box-shadow: 0 0 20px rgba(255,214,230,0.5);
+}
+.style:hover img,
+.style.active img {
+  box-shadow: 0 0 20px rgba(255, 214, 230, 0.8);
+  border: 1px solid #d4af37;
+}
 .style.disabled { opacity: 0.5; pointer-events: none; }
 #style-limit-msg {
   color: var(--accent);

--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -86,10 +86,13 @@
     $('#branch-select').val(slug);
     styleSel = [];
     $('#style-list').empty();
+    $('#phone-carousel').empty();
     toArray(wizardData.style).forEach(function(s){
       if(s.branch===slug){
         var img = s.icon ? '<img src="'+s.icon+'" alt="">' : '';
-        $('#style-list').append('<div class="style" data-title="'+s.title+'">'+img+'<span>'+s.title+'</span></div>');
+        var item = '<div class="style" data-title="'+s.title+'">'+img+'<span>'+s.title+'</span></div>';
+        $('#style-list').append(item);
+        $('#phone-carousel').append(item);
       }
     });
     $('#style-header').fadeIn(200);
@@ -108,7 +111,7 @@
     }
   });
 
-  $('#style-list').on('click','.style',function(){
+  $('#style-list, #phone-carousel').on('click','.style',function(){
     var title=$(this).data('title');
     if($(this).hasClass('active')){
       $(this).removeClass('active');

--- a/templates/wizard-page.php
+++ b/templates/wizard-page.php
@@ -28,6 +28,7 @@
     </div>
     <h3 id="style-header" class="subheadline" style="display:none">Wybierz, które nasze realizacje Ci się podobają (maks. 5)</h3>
     <div class="grid" id="style-list"></div>
+    <div id="phone-carousel" class="phone-carousel"></div>
     <div id="after-style" style="display:none">
       <h4>Informacje dodatkowe</h4>
       <textarea id="notes" placeholder="Opisz styl, jaki Ci się podoba"></textarea>


### PR DESCRIPTION
## Summary
- add phone-style carousel to step 1 markup
- enhance wizard CSS for carousel and style tiles
- extend JS logic to populate and handle phone carousel

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686eba4066ec8332bef3210cc39aea76