### PR TITLE
Enhance glass control focus styling

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -199,6 +199,19 @@ button:hover {
   outline: 1px solid #3f3d38;
   border-radius: 8px;
   backdrop-filter: blur(10px);
+  position: relative;
+  overflow: hidden;
+}
+.glass-control::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--accent);
+  transition: background-color .3s;
+  pointer-events: none;
 }
 
 textarea,
@@ -220,6 +233,12 @@ select:focus {
   outline: 1px solid #d1a54096;
   box-shadow: 0 4px 20px rgba(255,255,255,0.2);
   background-color: #141919;
+}
+.glass-control:focus {
+  box-shadow: 0 0 8px rgba(188,217,255,0.8), 0 4px 20px rgba(255,255,255,0.2);
+}
+.glass-control:focus::after {
+  background-color: #bcd9ff;
 }
 
 input[type=checkbox] {

--- a/templates/wizard-page.php
+++ b/templates/wizard-page.php
@@ -30,8 +30,8 @@
     <div class="grid" id="style-list"></div>
     <div id="after-style" style="display:none">
       <h4>Informacje dodatkowe</h4>
-      <textarea id="notes" placeholder="Opisz styl, jaki Ci się podoba"></textarea>
-      <input id="nip" placeholder="NIP firmy">
+      <textarea id="notes" class="glass-control" placeholder="Opisz styl, jaki Ci się podoba"></textarea>
+      <input id="nip" class="glass-control" placeholder="NIP firmy">
       <label class="rodo-label"><input type="checkbox" id="rodo"><span class="custom-checkbox"></span> Zgoda na przetwarzanie danych zgodnie z naszą <a href="/polityka-prywatnosci" target="_blank">polityką prywatności</a></label>
       <textarea id="notes" class="glass-control" placeholder="Opisz styl jaki Ci się podoba"></textarea>
       <input id="nip" class="glass-control" placeholder="NIP firmy">
@@ -71,9 +71,9 @@
     <div id="budget-summary"></div>
     <div id="summary-list"></div>
     <h3 class="subheadline">E-mail do przesłania wyceny</h3>
-    <input id="email" placeholder="Twój e-mail">
+    <input id="email" class="glass-control" placeholder="Twój e-mail">
     <h3>Email do przesłania wyceny</h3>
-    <input id="email" placeholder="Twój email">
+    <input id="email" class="glass-control" placeholder="Twój email">
     <button id="finish" class="cta-btn" disabled>Prześlij wycenę</button>
     <input id="email" class="glass-control" placeholder="Twój email">
     <button id="finish" disabled>Prześlij wycenę</button>


### PR DESCRIPTION
## Summary
- add underline pseudo-element for `.glass-control`
- style `.glass-control:focus` with pastel-blue glow
- ensure every select box, textarea and text input uses `.glass-control`

## Testing
- `php -l wizard-konfigurator.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eba43d9848332a9ee8a7494f80898