### PR TITLE
Update style selection CSS

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -373,9 +373,26 @@ input::placeholder {
 }
 .phone-carousel::-webkit-scrollbar { display: none; }
 .phone-carousel .style { flex: 0 0 auto; scroll-snap-align: start; }
-.style { position: relative; }
-.style img { display: block; width: 100%; height: auto; border-radius: 8px; }
-.style.disabled { opacity: 0.5; pointer-events: none; }
+.style {
+  position: relative;
+  transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out,
+    opacity 0.2s ease-in-out;
+}
+.style img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  transition: opacity 0.2s ease-in-out;
+}
+.style.active {
+  border: 1px solid #f6e27f;
+  box-shadow: 0 0 16px rgba(251, 222, 188, 0.8);
+}
+.style.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
 #style-limit-msg {
   color: var(--accent);
   text-align: center;


### PR DESCRIPTION
## Summary
- highlight selected style blocks with a gold border and pastel glow
- fade disabled style blocks
- add `ease-in-out` transitions for style selection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686eba4597288332b03ef8d707e0da94