### PR TITLE
Fix duplicate elements on wizard page

### DIFF
--- a/templates/wizard-page.php
+++ b/templates/wizard-page.php
@@ -30,12 +30,9 @@
     <div class="grid" id="style-list"></div>
     <div id="after-style" style="display:none">
       <h4>Informacje dodatkowe</h4>
-      <textarea id="notes" placeholder="Opisz styl, jaki Ci się podoba"></textarea>
-      <input id="nip" placeholder="NIP firmy">
-      <label class="rodo-label"><input type="checkbox" id="rodo"><span class="custom-checkbox"></span> Zgoda na przetwarzanie danych zgodnie z naszą <a href="/polityka-prywatnosci" target="_blank">polityką prywatności</a></label>
       <textarea id="notes" class="glass-control" placeholder="Opisz styl jaki Ci się podoba"></textarea>
       <input id="nip" class="glass-control" placeholder="NIP firmy">
-      <label class="rodo-label"><input type="checkbox" id="rodo"> Zgoda na przetwarzanie danych zgodnie z naszą <a href="/polityka-prywatnosci" target="_blank">polityką prywatności</a></label>
+      <label class="rodo-label"><input type="checkbox" id="rodo"><span class="custom-checkbox"></span> Zgoda na przetwarzanie danych zgodnie z naszą <a href="/polityka-prywatnosci" target="_blank">polityką prywatności</a></label>
       <button id="next-1" class="cta-btn">Dalej</button>
     </div>
   </div>
@@ -71,12 +68,8 @@
     <div id="budget-summary"></div>
     <div id="summary-list"></div>
     <h3 class="subheadline">E-mail do przesłania wyceny</h3>
-    <input id="email" placeholder="Twój e-mail">
-    <h3>Email do przesłania wyceny</h3>
-    <input id="email" placeholder="Twój email">
-    <button id="finish" class="cta-btn" disabled>Prześlij wycenę</button>
     <input id="email" class="glass-control" placeholder="Twój email">
-    <button id="finish" disabled>Prześlij wycenę</button>
+    <button id="finish" class="cta-btn" disabled>Prześlij wycenę</button>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- clean up `templates/wizard-page.php` to remove duplicate fields
- keep a single email input and finish button
- ensure remaining inputs use glass control and CTA styles

## Testing
- `php -l templates/wizard-page.php`

------
https://chatgpt.com/codex/tasks/task_e_686eba49bc1083329f3e79c446794bf3