### PR TITLE
Remove extra info from step 1

### DIFF
--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -35,9 +35,8 @@
   }
 
   function updateNext1(){
-    var nipFilled = $('#nip').val().trim() !== '';
-    var rodoOk    = $('#rodo').prop('checked');
-    var allOk     = styleSel.length >= 1 && nipFilled && rodoOk;
+    var rodoOk = $('#rodo').prop('checked');
+    var allOk  = styleSel.length >= 1 && rodoOk;
 
     if(allOk){
       $('#next-1').show();
@@ -140,15 +139,13 @@
     updateNext1();
   });
 
-  $('#nip').on('input', updateNext1);
   $('#rodo').on('change', function(){
     $(this).next('.custom-checkbox').toggleClass('checked', this.checked);
     updateNext1();
   });
   $('#next-1').click(function(){
     if(!$('#rodo').prop('checked')) return alert('Zgoda RODO wymagana');
-    if($('#nip').val().trim()==='') return alert('Podaj NIP firmy');
-    save({branza:$('#branch-select').val(), style:styleSel.join(','), notes:$('#notes').val(), nip:$('#nip').val(), rodo:1},function(){
+    save({branza:$('#branch-select').val(), style:styleSel.join(','), rodo:1},function(){
       $('#step-1').fadeOut(200,function(){ $('#step-2').fadeIn(200); setProgress(2); });
     });
   });

--- a/templates/wizard-page.php
+++ b/templates/wizard-page.php
@@ -26,13 +26,10 @@
         <option value="" selected disabled>Wybierz branżę</option>
       </select>
     </div>
-    <h3 id="style-header" class="subheadline" style="display:none">Wybierz, które nasze realizacje Ci się podobają (maks. 5)</h3>
     <div class="grid" id="style-list"></div>
     <div id="phone-carousel" class="phone-carousel"></div>
+    <h3 id="style-header" class="subheadline" style="display:none">Wybierz przykłady, które Ci się podobają (max 5)</h3>
     <div id="after-style" style="display:none">
-      <h4>Informacje dodatkowe</h4>
-      <textarea id="notes" class="glass-control" placeholder="Opisz styl, jaki Ci się podoba"></textarea>
-      <input id="nip" class="glass-control" placeholder="NIP firmy">
       <label class="rodo-label"><input type="checkbox" id="rodo"><span class="custom-checkbox"></span> Zgoda na przetwarzanie danych zgodnie z naszą <a href="/polityka-prywatnosci" target="_blank">polityką prywatności</a></label>
       <button id="next-1" class="cta-btn">Dalej</button>
     </div>


### PR DESCRIPTION
## Summary
- remove the additional info and NIP inputs from the first wizard step
- update frontend script to only require RODO consent
- move the "choose examples" message below the style tiles and adjust its text

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed290a78c83328632fb27d47898e8