### PR TITLE
Add carousel for style selection

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -535,3 +535,62 @@ input::placeholder {
   font-weight: 600;
   text-transform: uppercase;
 }
+
+/* Style carousel layout */
+.style-carousel {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin: 20px 0;
+}
+
+.carousel-arrow {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--header-color);
+  font-size: 32px;
+}
+
+.carousel-arrow:disabled {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+#style-list {
+  display: flex;
+  overflow: hidden;
+  width: 80%;
+  transition: transform 0.4s ease;
+}
+
+#style-list .style {
+  flex: 0 0 33.333%;
+  margin: 0 5px;
+  box-shadow: none;
+  border: none;
+  background: none;
+  opacity: 0.6;
+  transition: transform 0.4s ease, opacity 0.4s ease;
+}
+
+#style-list .style.center {
+  transform: scale(1.2);
+  opacity: 1;
+  z-index: 1;
+}
+
+#style-list .style.side-left,
+#style-list .style.side-right {
+  transform: scale(0.9);
+}
+
+#style-list .style.active::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 8px;
+  box-shadow: 0 0 30px rgba(185, 228, 227, 0.8);
+  z-index: -1;
+}

--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -5,6 +5,7 @@
   var postId = 0;
   var styleSel = [];
   var styleLimit = 5;
+  var styleIndex = 0;
   var selectedFeatures = [];
   var selectedGoals = [];
 
@@ -58,6 +59,7 @@
   }
   setProgress(1);
   $('#next-1').hide();
+  $('.style-carousel').hide();
   function save(meta, cb){
     $.post(wizardData.ajaxurl, {
       action: 'save_wizard_step',
@@ -71,7 +73,24 @@
   }
   var $branchSelect = $('#branch-select');
   var $styleLimitMsg = $('<div id="style-limit-msg" class="hidden">Możesz wybrać maksymalnie '+styleLimit+' stylów</div>');
-  $('#style-list').after($styleLimitMsg);
+  $('.style-carousel').after($styleLimitMsg);
+
+  function updateStyleCarousel(){
+    var $track = $('#style-list');
+    var $items = $track.children('.style');
+    var maxIndex = Math.max(0, $items.length - 3);
+    styleIndex = Math.min(styleIndex, maxIndex);
+    styleIndex = Math.max(0, styleIndex);
+    var offset = -(styleIndex * 33.3333);
+    $track.css('transform', 'translateX(' + offset + '%)');
+    $items.removeClass('center side-left side-right');
+    $items.eq(styleIndex).addClass('side-left');
+    $items.eq(styleIndex + 1).addClass('center');
+    $items.eq(styleIndex + 2).addClass('side-right');
+    $('.carousel-prev').prop('disabled', styleIndex===0);
+    $('.carousel-next').prop('disabled', styleIndex>=maxIndex);
+    $('.carousel-arrow').toggle($items.length>3);
+  }
   $branchSelect.empty().append('<option value="" selected disabled>Wybierz branżę</option>');
   toArray(wizardData['branże']).forEach(function(b){
     $branchSelect.append('<option value="'+b.slug+'">'+b.title+'</option>');
@@ -97,6 +116,9 @@
     $('.style').removeClass('disabled');
     $styleLimitMsg.addClass('hidden');
     $('#next-1').prop('disabled', true).hide();
+    styleIndex = 0;
+    updateStyleCarousel();
+    $('.style-carousel').fadeIn(200);
     updateNext1();
   }
 
@@ -135,6 +157,20 @@
       $('#after-style').hide();
     }
     updateNext1();
+  });
+
+  $('.carousel-next').on('click', function(){
+    var count = $('#style-list .style').length;
+    if(styleIndex < count - 3){
+      styleIndex++;
+      updateStyleCarousel();
+    }
+  });
+  $('.carousel-prev').on('click', function(){
+    if(styleIndex > 0){
+      styleIndex--;
+      updateStyleCarousel();
+    }
   });
 
   $('#rodo').on('change', function(){

--- a/templates/wizard-page.php
+++ b/templates/wizard-page.php
@@ -26,7 +26,11 @@
         <option value="" selected disabled>Wybierz branżę</option>
       </select>
     </div>
-    <div class="grid" id="style-list"></div>
+    <div class="style-carousel">
+      <button type="button" class="carousel-arrow carousel-prev">&#10094;</button>
+      <div id="style-list" class="carousel-track"></div>
+      <button type="button" class="carousel-arrow carousel-next">&#10095;</button>
+    </div>
     <h3 id="style-header" class="subheadline" style="display:none">Wybierz przykłady, które Ci się podobają (max 5)</h3>
     <div id="after-style">
       <label class="rodo-label"><input type="checkbox" id="rodo"><span class="custom-checkbox"></span> Zgoda na przetwarzanie danych zgodnie z naszą <a href="/polityka-prywatnosci" target="_blank">polityką prywatności</a></label>


### PR DESCRIPTION
## Summary
- switch style selector to a carousel with nav arrows
- add scaling styles for center/side items
- tweak JS to drive carousel and hide it until branch is picked

## Testing
- `php -l templates/wizard-page.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7105bc488332a73cf23386632102