### PR TITLE
Add badge settings for features

### DIFF
--- a/assets/css/wizard.css
+++ b/assets/css/wizard.css
@@ -602,3 +602,11 @@ input::placeholder {
   box-shadow: 0 0 30px rgba(185, 228, 227, 0.8);
   z-index: -1;
 }
+.feature-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 12px;
+  margin-right: 4px;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -54,6 +54,9 @@ jQuery(function($){
     });
     t.append('<tr data-index="'+idx+'">'+
       '<td><input name="konf_features['+idx+'][title]"></td>'+
+      '<td><input name="konf_features['+idx+'][desc]"></td>'+
+      '<td><input name="konf_features['+idx+'][badge_text]"></td>'+
+      '<td><input type="color" name="konf_features['+idx+'][badge_color]" value="#ffffff"></td>'+
       '<td><select name="konf_features['+idx+'][type]"><option value="funkcja">Funkcja</option><option value="automatyzacja">Automatyzacja</option><option value="integracja">Integracja</option></select></td>'+
       '<td><input name="konf_features['+idx+'][price]" placeholder="2000"></td>'+
       '<td>'+cele+'</td>'+

--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -27,7 +27,8 @@
       list.forEach(function(f){
         var desc=f.desc||f.description||'';
         var img = f.icon ? '<img src="'+f.icon+'" alt="">' : '';
-        table.append('<tr><td><label class="feature-tag" data-title="'+f.title+'" data-price="'+(f.price||0)+'">'+img+'<input type="checkbox" data-price="'+(f.price||0)+'" value="'+f.title+'"> <span>'+f.title+'</span></label></td><td>'+desc+'</td></tr>');
+        var badge=f.badge_text?'<span class="feature-badge" style="background:'+ (f.badge_color||'#ccc')+'">'+f.badge_text+'</span>':'';
+        table.append('<tr><td><label class="feature-tag" data-title="'+f.title+'" data-price="'+(f.price||0)+'">'+img+badge+'<input type="checkbox" data-price="'+(f.price||0)+'" value="'+f.title+'"> <span>'+f.title+'</span></label></td><td>'+desc+'</td></tr>');
       });
       table.append('<tr><td colspan="2"><label><input type="checkbox" value="inne-'+type+'"> inne, niestandardowe rozwiązania</label></td></tr>');
       $('#features-list').append(table);

--- a/wizard-konfigurator.php
+++ b/wizard-konfigurator.php
@@ -100,10 +100,13 @@ function kc_render_features() {
     if (!is_array($items)) $items = [];
     $cele  = get_option('konf_cele', []);
     if (!is_array($cele)) $cele = [];
-    echo '<table><thead><tr><th>Nazwa</th><th>Typ</th><th>Cena</th><th>Przypisane cele</th><th></th></tr></thead><tbody>';
+    echo '<table><thead><tr><th>Tytuł</th><th>Opis</th><th>Badge</th><th>Kolor</th><th>Typ</th><th>Cena</th><th>Przypisane cele</th><th></th></tr></thead><tbody>';
     foreach ($items as $i => $f) {
         echo "<tr data-index='{$i}'>";
         echo "<td><input name='konf_features[{$i}][title]' value='" . esc_attr($f['title']) . "'></td>";
+        echo "<td><input name='konf_features[{$i}][desc]' value='" . esc_attr($f['desc']) . "'></td>";
+        echo "<td><input name='konf_features[{$i}][badge_text]' value='" . esc_attr($f['badge_text']) . "'></td>";
+        echo "<td><input type='color' name='konf_features[{$i}][badge_color]' value='" . esc_attr($f['badge_color']) . "'></td>";
         echo '<td><select name="konf_features['.$i.'][type]">'
            . '<option value="funkcja"'.($f['type']=='funkcja'?' selected':'').'>Funkcja</option>'
            . '<option value="automatyzacja"'.($f['type']=='automatyzacja'?' selected':'').'>Automatyzacja</option>'


### PR DESCRIPTION
## Summary
- enhance feature admin table with description and badge fields
- support new fields in admin JS for dynamic rows
- display badges on wizard page
- style feature badge

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_686f81c076b4833288800ea36552b853