### PR TITLE
Add option for style selection mode

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -2,6 +2,11 @@
 <div class="wrap">
   <h1>Wizard Konfigurator — Ustawienia</h1>
   <form method="post" action="options.php">
-    <?php settings_fields('kc_group'); do_settings_sections('wizard-konfigurator'); submit_button(); ?>
+    <?php settings_fields('kc_group'); do_settings_sections('wizard-konfigurator'); ?>
+    <h2>Tryb wyboru stylu</h2>
+    <?php $val = get_option('konf_style_multiselect', '1'); ?>
+    <label><input type="radio" name="konf_style_multiselect" value="0" <?php checked($val,'0'); ?>> pojedynczy</label>
+    <label><input type="radio" name="konf_style_multiselect" value="1" <?php checked($val,'1'); ?>> wielokrotny</label>
+    <?php submit_button(); ?>
   </form>
 </div>

--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -4,7 +4,9 @@
   }
   var postId = 0;
   var styleSel = [];
-  var styleLimit = 5;
+  var allowMulti = wizardData.styleMulti == '1';
+  var styleLimit = allowMulti ? 5 : 1;
+  $('#style-header').text('Wybierz przykłady, które Ci się podobają (max '+styleLimit+')');
   var styleIndex = 0;
   var selectedFeatures = [];
   var selectedGoals = [];
@@ -73,7 +75,9 @@
   }
   var $branchSelect = $('#branch-select');
   var $styleLimitMsg = $('<div id="style-limit-msg" class="hidden">Możesz wybrać maksymalnie '+styleLimit+' stylów</div>');
-  $('.style-carousel').after($styleLimitMsg);
+  if(allowMulti){
+    $('.style-carousel').after($styleLimitMsg);
+  }
 
   function updateStyleCarousel(){
     var $track = $('#style-list');
@@ -136,20 +140,30 @@
       $(this).removeClass('active');
       styleSel = styleSel.filter(function(t){ return t!==title; });
     }else{
-      if(styleSel.length>=styleLimit){
-        $styleLimitMsg.removeClass('hidden');
-        $('.style').not('.active').addClass('disabled');
-        return;
+      if(!allowMulti){
+        $('.style.active').removeClass('active');
+        styleSel = [title];
+      }else{
+        if(styleSel.length>=styleLimit){
+          $styleLimitMsg.removeClass('hidden');
+          $('.style').not('.active').addClass('disabled');
+          return;
+        }
+        styleSel.push(title);
       }
       $(this).addClass('active');
-      styleSel.push(title);
     }
-    if(styleSel.length<styleLimit){
+    if(allowMulti){
+      if(styleSel.length<styleLimit){
+        $('.style').removeClass('disabled');
+        $styleLimitMsg.addClass('hidden');
+      }else{
+        $('.style').not('.active').addClass('disabled');
+        $styleLimitMsg.removeClass('hidden');
+      }
+    }else{
       $('.style').removeClass('disabled');
       $styleLimitMsg.addClass('hidden');
-    }else{
-      $('.style').not('.active').addClass('disabled');
-      $styleLimitMsg.removeClass('hidden');
     }
     if(styleSel.length>=1){
       $('#after-style').fadeIn(200);

--- a/wizard-konfigurator.php
+++ b/wizard-konfigurator.php
@@ -17,11 +17,13 @@ add_action('admin_init', function() {
     register_setting('kc_group', 'konf_cele');
     register_setting('kc_group', 'konf_style');
     register_setting('kc_group', 'konf_features');
+    register_setting('kc_group', 'konf_style_multiselect');
     add_settings_section('kc_sec', 'Ustawienia Wizard Konfiguratora', null, 'wizard-konfigurator');
     add_settings_field('kc_field_branze', 'Branże', 'kc_render_branze', 'wizard-konfigurator', 'kc_sec');
     add_settings_field('kc_field_cele', 'Cele', 'kc_render_cele', 'wizard-konfigurator', 'kc_sec');
     add_settings_field('kc_field_style', 'Style', 'kc_render_style', 'wizard-konfigurator', 'kc_sec');
     add_settings_field('kc_field_feat', 'Funkcje/Integracje', 'kc_render_features', 'wizard-konfigurator', 'kc_sec');
+    add_settings_field('kc_field_style_multi', 'Wybór stylu', 'kc_render_style_multiselect', 'wizard-konfigurator', 'kc_sec');
 });
 
 // Admin scripts for dynamic fields and media uploader
@@ -120,6 +122,12 @@ function kc_render_features() {
     echo '</tbody></table><p><button id="kc_add_feature" class="button" type="button">Dodaj pozycję</button></p>';
 }
 
+function kc_render_style_multiselect() {
+    $val = get_option('konf_style_multiselect', '1');
+    echo '<label><input type="radio" name="konf_style_multiselect" value="0" '.checked($val, '0', false).'> pojedynczy</label><br>';
+    echo '<label><input type="radio" name="konf_style_multiselect" value="1" '.checked($val, '1', false).'> wielokrotny</label>';
+}
+
 // SETTINGS PAGE
 function kc_settings_page() {
     include plugin_dir_path(__FILE__) . 'admin/settings-page.php';
@@ -143,6 +151,7 @@ register_activation_hook(__FILE__, function() {
     ]);
     if (!is_array(get_option('konf_style'))) update_option('konf_style', []);
     if (!is_array(get_option('konf_features'))) update_option('konf_features', []);
+    if (get_option('konf_style_multiselect') === false) update_option('konf_style_multiselect', '1');
 });
 
 // SHORTCODE & AJAX
@@ -160,7 +169,8 @@ add_action('wp_enqueue_scripts', function() {
         'branże'  => array_values((array) get_option('konf_branze')),
         'cele'    => array_values((array) get_option('konf_cele')),
         'style'   => array_values((array) get_option('konf_style')),
-        'features'=> array_values((array) get_option('konf_features'))
+        'features'=> array_values((array) get_option('konf_features')),
+        'styleMulti' => get_option('konf_style_multiselect', '1')
     ]);
 });
 add_action('wp_ajax_save_wizard_step', 'kc_save_step');


### PR DESCRIPTION
## Summary
- register `konf_style_multiselect` plugin option
- show "pojedynczy"/"wielokrotny" radio buttons on settings page
- localize `styleMulti` to front end
- update wizard JS to respect single style selection when multiselect disabled

## Testing
- `php -v` *(fails: command not found)*
- `node -e "require('./assets/js/wizard.js')"`

------
https://chatgpt.com/codex/tasks/task_e_686f8717f35c8332a5655f6fab0408c5