### PR TITLE
Fix admin field duplication and carousel JS

### DIFF
--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -3,10 +3,6 @@
   <h1>Wizard Konfigurator — Ustawienia</h1>
   <form method="post" action="options.php">
     <?php settings_fields('kc_group'); do_settings_sections('wizard-konfigurator'); ?>
-    <h2>Tryb wyboru stylu</h2>
-    <?php $val = get_option('konf_style_multiselect', '1'); ?>
-    <label><input type="radio" name="konf_style_multiselect" value="0" <?php checked($val,'0'); ?>> pojedynczy</label>
-    <label><input type="radio" name="konf_style_multiselect" value="1" <?php checked($val,'1'); ?>> wielokrotny</label>
     <?php submit_button(); ?>
   </form>
 </div>

--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -83,37 +83,22 @@
   }
 
   function updateStyleCarousel(){
-      var $track = $('#style-list');
-      var $items = $track.children('.style');
-      var count = $items.length;
-      if(!count) return;
-
-      styleIndex = (styleIndex + count) % count;
-
-      var prevIndex = (styleIndex - 1 + count) % count;
-      var nextIndex = (styleIndex + 1) % count;
-
-      var offset = -((styleIndex - 1) * 33.3333);
-      $track.css('transform', 'translateX(' + offset + '%)');
-
-      $items.removeClass('center side-left side-right');
-      $items.eq(prevIndex).addClass('side-left');
-      $items.eq(styleIndex).addClass('center');
-      $items.eq(nextIndex).addClass('side-right');
-
-      $('.carousel-arrow').toggle(count>3);
     var $track = $('#style-list');
     var $items = $track.children('.style');
-    var count = $items.length;
+    var count   = $items.length;
     if(!count) return;
+
     styleIndex = (styleIndex % count + count) % count;
+
     var offset = styleIndex > 0 ? -(styleIndex * 33.3333) : 0;
     $track.css('transform', 'translateX(' + offset + '%)');
+
     $items.removeClass('center side-left side-right');
-    if(styleIndex > 0) $items.eq(styleIndex - 1).addClass('side-left');
+    $items.eq((styleIndex - 1 + count) % count).addClass('side-left');
     $items.eq(styleIndex).addClass('center');
-    if(styleIndex < count - 1) $items.eq(styleIndex + 1).addClass('side-right');
-    $('.carousel-arrow').toggle(count>1);
+    $items.eq((styleIndex + 1) % count).addClass('side-right');
+
+    $('.carousel-arrow').toggle(count > 1);
   }
   $branchSelect.empty().append('<option value="" selected disabled>Wybierz branżę</option>');
   toArray(wizardData['branże']).forEach(function(b){
@@ -196,29 +181,18 @@
   });
 
   $('.carousel-next').on('click', function(){
-      var count = $('#style-list .style').length;
-      if(count){
-        styleIndex = (styleIndex + 1) % count;
-        updateStyleCarousel();
-      }
-    });
-    $('.carousel-prev').on('click', function(){
-      var count = $('#style-list .style').length;
-      if(count){
-        styleIndex = (styleIndex - 1 + count) % count;
-        updateStyleCarousel();
-      }
-    });
     var count = $('#style-list .style').length;
-    if(!count) return;
-    styleIndex = (styleIndex + 1) % count;
-    updateStyleCarousel();
+    if(count){
+      styleIndex = (styleIndex + 1) % count;
+      updateStyleCarousel();
+    }
   });
   $('.carousel-prev').on('click', function(){
     var count = $('#style-list .style').length;
-    if(!count) return;
-    styleIndex = (styleIndex - 1 + count) % count;
-    updateStyleCarousel();
+    if(count){
+      styleIndex = (styleIndex - 1 + count) % count;
+      updateStyleCarousel();
+    }
   });
 
   $('#style-list').on('touchstart', function(e){
@@ -238,31 +212,20 @@
     if(isSwiping) e.preventDefault();
   });
   $('#style-list').on('touchend', function(e){
-      if(touchStartX === undefined) return;
-      var dx = (e.originalEvent.changedTouches[0] || {}).clientX - touchStartX;
-      var count = $('#style-list .style').length;
-      if(isSwiping && Math.abs(dx) > 50 && count){
-        if(dx < 0){
-          styleIndex = (styleIndex + 1) % count;
-          updateStyleCarousel();
-        } else if(dx > 0){
-          styleIndex = (styleIndex - 1 + count) % count;
-          updateStyleCarousel();
-        }
     if(touchStartX === undefined) return;
     var dx = (e.originalEvent.changedTouches[0] || {}).clientX - touchStartX;
     var count = $('#style-list .style').length;
-    if(isSwiping && Math.abs(dx) > 50){
+    if(isSwiping && Math.abs(dx) > 50 && count){
       if(dx < 0){
         styleIndex = (styleIndex + 1) % count;
-        updateStyleCarousel();
       }else if(dx > 0){
         styleIndex = (styleIndex - 1 + count) % count;
-        updateStyleCarousel();
       }
-      touchStartX = touchStartY = undefined;
-      isSwiping = false;
-    });
+      updateStyleCarousel();
+    }
+    touchStartX = touchStartY = undefined;
+    isSwiping = false;
+  });
 
   $('#rodo').on('change', function(){
     $(this).next('.custom-checkbox').toggleClass('checked', this.checked);


### PR DESCRIPTION
## Summary
- remove duplicate style mode radios from settings page
- clean up carousel functions and touch handlers to avoid JS errors

## Testing
- `npx eslint assets/js/wizard.js` *(fails: ESLint couldn't find a config)*
- `node -c assets/js/wizard.js`

------
https://chatgpt.com/codex/tasks/task_e_686f8ab34b3083328d1ccaef2c940bea